### PR TITLE
OpenAPI 3.1 support

### DIFF
--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -50,7 +50,7 @@ module Committee
     # @param [Hash] hash
     # @return [Committee::Driver]
     def self.load_from_data(hash, schema_path = nil, parser_options = {})
-      if hash['openapi']&.start_with?('3.0.')
+      if hash['openapi']&.start_with?('3.')
         # From the next major version, we want to ensure `{ strict_reference_validation: true }`
         # as a parser option here, but since it may break existing implementations, just warn
         # if it is not explicitly set. See: https://github.com/interagent/committee/issues/343#issuecomment-997400329


### PR DESCRIPTION
## Overview
When using OpenAPI 3.1, assert_response_schema_confirm did not work correctly because an appropriate Driver was not selected.

OpenAPI 3 Driver was selected for 3.0.x only, so a minor adjustment was made so that it is selected for all 3.x.