### PR TITLE
Remove openapi_parser from related gems

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency "json_schema", "~> 0.14", ">= 0.14.3"
 
   s.add_dependency "rack", ">= 1.5"
-  s.add_dependency "openapi_parser", "1.0.0.beta1"
 
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rack-test", "~> 0.6"


### PR DESCRIPTION
Remove openapi_parser from related gems

### usage
#### use Repository
gemfile
```
group :development, :test do
  gem "committee", git: "https://github.com/cat-algorithm/committee", branch: "feature/additional_properties_required"
  gem "openapi_parser", git: "https://github.com/cat-algorithm/openapi_parser", branch: "master"
  gem "committee-rails"
end
```